### PR TITLE
Fix update HabitEvent picture bug

### DIFF
--- a/app/src/main/java/com/example/ohthmhyh/activities/UpdateHabitEventActivity.java
+++ b/app/src/main/java/com/example/ohthmhyh/activities/UpdateHabitEventActivity.java
@@ -151,6 +151,7 @@ public class UpdateHabitEventActivity extends AppCompatActivity {
             habitEvent.getBitmapPic(new HabitEvent.BMPcallback() {
                 @Override
                 public void onBMPcallback(Bitmap bitmap) {
+                    UpdateHabitEventActivity.this.bitmap = bitmap;  // Set this instance's bitmap.
                     pictureImageView.setImageBitmap(bitmap);
                 }
             });


### PR DESCRIPTION
If one created a HabitEvent with a custom picture and then went to edit the HabitEvent without changing the picture, the picture would change to the default HabitEvent picture.

This change fixes that.