### PR TITLE
Fix habits today

### DIFF
--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitFeedRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitFeedRecyclerViewAdapter.java
@@ -7,6 +7,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 
 import com.example.ohthmhyh.database.HabitList;
+import com.example.ohthmhyh.entities.Habit;
 
 import java.util.ArrayList;
 
@@ -18,10 +19,13 @@ public class HabitFeedRecyclerViewAdapter extends HabitRecyclerViewAdapter{
      * Creates an instance of the custom RecyclerView adapter used for showing habits in the feed
      * @param context   Context from the activity
      * @param habitList The HabitList containing the habits
+     * @param content The Habits to display in the RecyclerView
+     * @param usernames The usernames associated with each Habit
      */
     public HabitFeedRecyclerViewAdapter(Context context, HabitList habitList,
+                                        ArrayList<Habit> content,
                                         ArrayList<String> usernames) {
-        super(context, habitList);
+        super(context, habitList, content);
         this.usernames = usernames;
     }
 

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitFeedRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitFeedRecyclerViewAdapter.java
@@ -6,7 +6,6 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
-import com.example.ohthmhyh.database.HabitList;
 import com.example.ohthmhyh.entities.Habit;
 
 import java.util.ArrayList;
@@ -18,14 +17,13 @@ public class HabitFeedRecyclerViewAdapter extends HabitRecyclerViewAdapter{
     /**
      * Creates an instance of the custom RecyclerView adapter used for showing habits in the feed
      * @param context   Context from the activity
-     * @param habitList The HabitList containing the habits
      * @param content The Habits to display in the RecyclerView
      * @param usernames The usernames associated with each Habit
      */
-    public HabitFeedRecyclerViewAdapter(Context context, HabitList habitList,
+    public HabitFeedRecyclerViewAdapter(Context context,
                                         ArrayList<Habit> content,
                                         ArrayList<String> usernames) {
-        super(context, habitList, content);
+        super(context, content);
         this.usernames = usernames;
     }
 

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewAdapter.java
@@ -64,18 +64,22 @@ public abstract class HabitRecyclerViewAdapter extends RecyclerView.Adapter<Habi
     }
 
 
-    HabitList habitList;
-    Context context;
+    protected ArrayList<Habit> content;
+    protected HabitList habitList;
+    protected Context context;
 
 
     /**
      * Creates an instance of the custom RecyclerView adapter used for showing habits
-     * @param habitList The HabitList containing the habits
      * @param context Context from the activity
+     * @param habitList The HabitList containing all the Habits
+     * @param content The list of Habits to display in the RecyclerView
      */
-    public HabitRecyclerViewAdapter(Context context, HabitList habitList) {
-        this.habitList = habitList;
+    public HabitRecyclerViewAdapter(
+            Context context, HabitList habitList, ArrayList<Habit> content) {
         this.context = context;
+        this.habitList = habitList;
+        this.content = content;
     }
 
 
@@ -102,8 +106,8 @@ public abstract class HabitRecyclerViewAdapter extends RecyclerView.Adapter<Habi
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, @SuppressLint("RecyclerView") int position) {
         // set the content of the views in the RecyclerView element
-        holder.name.setText(habitList.getHabit(position).getName());
-        holder.description.setText(habitList.getHabit(position).getDescription());
+        holder.name.setText(content.get(position).getName());
+        holder.description.setText(content.get(position).getDescription());
         holder.username.setVisibility(View.INVISIBLE);  // The username is invisible by default.
         holder.checkbox.setVisibility(View.INVISIBLE);  // Checkbox is invisible by default.
         setProgressBar(holder, position);
@@ -113,11 +117,11 @@ public abstract class HabitRecyclerViewAdapter extends RecyclerView.Adapter<Habi
 
     /**
      * Returns the amount of items in the RecyclerView
-     * @return habitList.size()
+     * @return content.size()
      */
     @Override
     public int getItemCount() {
-        return habitList.size();
+        return content.size();
     }
 
 
@@ -128,7 +132,7 @@ public abstract class HabitRecyclerViewAdapter extends RecyclerView.Adapter<Habi
      * @param position the position of the habit in the list that we are using
      */
     public void setProgressBar(@NonNull ViewHolder holder, @SuppressLint("RecyclerView") int position) {
-        double progress = habitList.getHabit(position).getAdherence(LocalDate.now());
+        double progress = content.get(position).getAdherence(LocalDate.now());
 
         //set colours of bar and text to grey
         holder.percent.setTextColor(context.getResources().getColor(R.color.progressBarGray));
@@ -165,7 +169,7 @@ public abstract class HabitRecyclerViewAdapter extends RecyclerView.Adapter<Habi
      */
     public void setDays(@NonNull ViewHolder holder, @SuppressLint("RecyclerView") int position) {
 
-        ArrayList<Habit.Days> days = habitList.getHabit(position).getSchedule();
+        ArrayList<Habit.Days> days = content.get(position).getSchedule();
         final float minOpacity = 0.3f;
 
         // set all "day" views to default font

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewAdapter.java
@@ -18,7 +18,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ohthmhyh.Constants;
 import com.example.ohthmhyh.R;
-import com.example.ohthmhyh.database.HabitList;
 import com.example.ohthmhyh.entities.Habit;
 
 import java.time.LocalDate;
@@ -65,20 +64,16 @@ public abstract class HabitRecyclerViewAdapter extends RecyclerView.Adapter<Habi
 
 
     protected ArrayList<Habit> content;
-    protected HabitList habitList;
     protected Context context;
 
 
     /**
      * Creates an instance of the custom RecyclerView adapter used for showing habits
      * @param context Context from the activity
-     * @param habitList The HabitList containing all the Habits
      * @param content The list of Habits to display in the RecyclerView
      */
-    public HabitRecyclerViewAdapter(
-            Context context, HabitList habitList, ArrayList<Habit> content) {
+    public HabitRecyclerViewAdapter(Context context, ArrayList<Habit> content) {
         this.context = context;
-        this.habitList = habitList;
         this.content = content;
     }
 

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewGestureAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewGestureAdapter.java
@@ -14,7 +14,10 @@ import androidx.recyclerview.widget.ItemTouchHelper;
 
 import com.example.ohthmhyh.R;
 import com.example.ohthmhyh.database.HabitList;
+import com.example.ohthmhyh.entities.Habit;
 import com.example.ohthmhyh.interfaces.ItemTransportable;
+
+import java.util.ArrayList;
 
 public class HabitRecyclerViewGestureAdapter extends HabitRecyclerViewAdapter
         implements ItemTransportable {
@@ -127,11 +130,13 @@ public class HabitRecyclerViewGestureAdapter extends HabitRecyclerViewAdapter
     /**
      * Creates the custom adapter instance
      * @param context          Context from the activity
-     * @param touchListener A thing that does touch actions
      * @param habitList        The HabitList containing the habits
+     * @param content          The Habits to display in the RecyclerView
+     * @param touchListener    A thing that does touch actions
      */
-    public HabitRecyclerViewGestureAdapter(Context context, HabitList habitList, OnTouchListener touchListener) {
-        super(context, habitList);
+    public HabitRecyclerViewGestureAdapter(Context context, HabitList habitList,
+                                           ArrayList<Habit> content, OnTouchListener touchListener) {
+        super(context, habitList, content);
         this.touchListener = touchListener;
     }
 
@@ -174,6 +179,10 @@ public class HabitRecyclerViewGestureAdapter extends HabitRecyclerViewAdapter
                     // when "yes" is pressed, delete the habit
                     @Override
                     public void onClick(DialogInterface dialog, int whichButton) {
+                        // Remove the Habit from the content.
+                        content.remove(position);
+
+                        // Remove the Habit from the database.
                         habitList.removeHabit(position);
                         notifyItemRemoved(position);
                     }})
@@ -194,7 +203,13 @@ public class HabitRecyclerViewGestureAdapter extends HabitRecyclerViewAdapter
      */
     @Override
     public void onItemMoved(int fromPosition, int toPosition) {
+        // Move the Habit in the content.
+        Habit habitToMove = content.remove(fromPosition);
+        content.add(toPosition, habitToMove);
+
+        // Move the Habit in the database.
         habitList.moveHabit(fromPosition, toPosition);
+
         notifyItemMoved(fromPosition, toPosition);
     }
 

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewGestureAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitRecyclerViewGestureAdapter.java
@@ -123,6 +123,7 @@ public class HabitRecyclerViewGestureAdapter extends HabitRecyclerViewAdapter
     }
 
 
+    private HabitList habitList;
     private OnTouchListener touchListener;
     private ItemTouchHelper touchHelper;
 
@@ -136,7 +137,8 @@ public class HabitRecyclerViewGestureAdapter extends HabitRecyclerViewAdapter
      */
     public HabitRecyclerViewGestureAdapter(Context context, HabitList habitList,
                                            ArrayList<Habit> content, OnTouchListener touchListener) {
-        super(context, habitList, content);
+        super(context, content);
+        this.habitList = habitList;
         this.touchListener = touchListener;
     }
 

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitTodayRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitTodayRecyclerViewAdapter.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
  */
 public class HabitTodayRecyclerViewAdapter extends HabitRecyclerViewAdapter {
 
+    private HabitList habitList;
+    
     /**
      * Creates the custom adapter instance
      * @param context Context from the activity
@@ -25,7 +27,8 @@ public class HabitTodayRecyclerViewAdapter extends HabitRecyclerViewAdapter {
      */
     public HabitTodayRecyclerViewAdapter(Context context, HabitList habitList,
                                          ArrayList<Habit> content) {
-        super(context, habitList, content);
+        super(context, content);
+        this.habitList = habitList;
     }
 
     //sets the things in the display

--- a/app/src/main/java/com/example/ohthmhyh/adapters/HabitTodayRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/ohthmhyh/adapters/HabitTodayRecyclerViewAdapter.java
@@ -10,6 +10,8 @@ import androidx.annotation.NonNull;
 import com.example.ohthmhyh.database.HabitList;
 import com.example.ohthmhyh.entities.Habit;
 
+import java.util.ArrayList;
+
 /**
  * A simple RecycleviewAdapter for the Habit list.
  */
@@ -17,12 +19,13 @@ public class HabitTodayRecyclerViewAdapter extends HabitRecyclerViewAdapter {
 
     /**
      * Creates the custom adapter instance
-     * @param habitList The HabitList containing the habits
      * @param context Context from the activity
-     * The CERecycleviewAdapter creater Needs and array, context and a touch Listener
+     * @param habitList The HabitList containing the habits
+     * @param content The Habits to display in the RecyclerView
      */
-    public HabitTodayRecyclerViewAdapter(Context context, HabitList habitList) {
-        super(context, habitList);
+    public HabitTodayRecyclerViewAdapter(Context context, HabitList habitList,
+                                         ArrayList<Habit> content) {
+        super(context, habitList, content);
     }
 
     //sets the things in the display
@@ -33,7 +36,7 @@ public class HabitTodayRecyclerViewAdapter extends HabitRecyclerViewAdapter {
 
         super.onBindViewHolder(holder, position);
 
-        Habit h = habitList.getHabit(position);
+        Habit habit = content.get(position);
 
         // Hide the username TextView but show the Checkbox.
         holder.username.setVisibility(View.INVISIBLE);
@@ -43,17 +46,17 @@ public class HabitTodayRecyclerViewAdapter extends HabitRecyclerViewAdapter {
             @Override
             public void onClick(View view) {
                 if(holder.checkbox.isChecked()){
-                    Log.d("tag", h.getName() + " checked");
-                    int index = habitList.getHabitIndex(h);
+                    Log.d("tag", habit.getName() + " checked");
+                    int index = habitList.getHabitIndex(habit);  // Get the index of the Habit.
 
-                    h.logCompleted();
-                    habitList.setHabit(index, h);
+                    habit.logCompleted();
+                    habitList.setHabit(index, habit);
                 } else {
-                    Log.d("tag", h.getName() + " unchecked");
-                    int index = habitList.getHabitIndex(h);
+                    Log.d("tag", habit.getName() + " unchecked");
+                    int index = habitList.getHabitIndex(habit);  // Get the index of the Habit.
 
-                    h.undoCompleted();
-                    habitList.setHabit(index, h);
+                    habit.undoCompleted();
+                    habitList.setHabit(index, habit);
                 }
             }
         });

--- a/app/src/main/java/com/example/ohthmhyh/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/ohthmhyh/fragments/FeedFragment.java
@@ -53,7 +53,8 @@ public class FeedFragment extends Fragment{
         habitList.setHabitList(feedHabits);
 
         // set up the feed recyclerView
-        adapter = new HabitFeedRecyclerViewAdapter(view.getContext(), habitList, usernames);
+        adapter = new HabitFeedRecyclerViewAdapter(
+                view.getContext(), habitList, feedHabits, usernames);
         feedRV.setLayoutManager(new LinearLayoutManager(view.getContext()));
         feedRV.setHasFixedSize(true);
         feedRV.setAdapter(adapter);

--- a/app/src/main/java/com/example/ohthmhyh/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/ohthmhyh/fragments/FeedFragment.java
@@ -48,10 +48,6 @@ public class FeedFragment extends Fragment{
         View view = inflater.inflate(R.layout.fragment_feed, container, false);
         RecyclerView feedRV = view.findViewById(R.id.feed_RV);
 
-        // make the feedHabits into a HabitList for compatibility with the recyclerView adapter
-        HabitList habitList = new HabitList();
-        habitList.setHabitList(feedHabits);
-
         // set up the feed recyclerView
         adapter = new HabitFeedRecyclerViewAdapter(view.getContext(), feedHabits, usernames);
         feedRV.setLayoutManager(new LinearLayoutManager(view.getContext()));

--- a/app/src/main/java/com/example/ohthmhyh/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/ohthmhyh/fragments/FeedFragment.java
@@ -53,8 +53,7 @@ public class FeedFragment extends Fragment{
         habitList.setHabitList(feedHabits);
 
         // set up the feed recyclerView
-        adapter = new HabitFeedRecyclerViewAdapter(
-                view.getContext(), habitList, feedHabits, usernames);
+        adapter = new HabitFeedRecyclerViewAdapter(view.getContext(), feedHabits, usernames);
         feedRV.setLayoutManager(new LinearLayoutManager(view.getContext()));
         feedRV.setHasFixedSize(true);
         feedRV.setAdapter(adapter);

--- a/app/src/main/java/com/example/ohthmhyh/fragments/HabitsFragment.java
+++ b/app/src/main/java/com/example/ohthmhyh/fragments/HabitsFragment.java
@@ -27,6 +27,8 @@ import com.example.ohthmhyh.database.HabitList;
 import com.example.ohthmhyh.R;
 import com.example.ohthmhyh.helpers.TransportableTouchHelper;
 
+import java.util.ArrayList;
+
 /**
  * A simple {@link Fragment} subclass.
  */
@@ -37,6 +39,7 @@ public class HabitsFragment extends Fragment implements HabitRecyclerViewGesture
     private int chosenHabitIndex = -1;
     private ActivityResultLauncher<Intent> resultLauncher;
     private HabitList habitList;
+    private ArrayList<Habit> listOfHabits;
     private HabitRecyclerViewGestureAdapter adapter;
     private DatabaseAdapter databaseAdapter;
 
@@ -70,9 +73,16 @@ public class HabitsFragment extends Fragment implements HabitRecyclerViewGesture
             public void onHabitCallback(HabitList hList) {
                 habitList = hList;
 
+                // Populate the ArrayList of Habits with all the Habits in the database.
+                listOfHabits = new ArrayList<>();
+                for (int i = 0; i < habitList.size(); i++) {
+                    listOfHabits.add(habitList.getHabit(i));
+                }
+
                 recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
                 recyclerView.setHasFixedSize(true);
-                adapter = new HabitRecyclerViewGestureAdapter(getContext(),  habitList, HabitsFragment.this);
+                adapter = new HabitRecyclerViewGestureAdapter(
+                        getContext(),  habitList, listOfHabits, HabitsFragment.this);
                 ItemTouchHelper.Callback callback = new TransportableTouchHelper(adapter);
                 ItemTouchHelper itemTouchHelper = new ItemTouchHelper(callback);
                 adapter.setTouchHelper(itemTouchHelper);
@@ -96,8 +106,16 @@ public class HabitsFragment extends Fragment implements HabitRecyclerViewGesture
                             Habit habit = (Habit) result.getData().getSerializableExtra(
                                     ARG_RETURNED_HABIT);
                             if (chosenHabitIndex < 0) {
+                                // Add the Habit to the ArrayList of Habits.
+                                listOfHabits.add(habit);
+
+                                // Also add this Habit to the database.
                                 habitList.addHabit(habit);
                             } else {
+                                // Replace this Habit in the ArrayList of Habits.
+                                listOfHabits.set(chosenHabitIndex, habit);
+
+                                // Also replace this Habit in the database.
                                 habitList.replaceHabit(chosenHabitIndex, habit);
                             }
                             adapter.notifyDataSetChanged();
@@ -128,7 +146,7 @@ public class HabitsFragment extends Fragment implements HabitRecyclerViewGesture
         Intent intent = new Intent(getActivity(), UpdateHabitActivity.class);
         if (habitIndex >= 0) {
             // Pass the Habit to the UpdateHabitActivity.
-            intent.putExtra(UpdateHabitActivity.ARG_HABIT, habitList.getHabit(habitIndex));
+            intent.putExtra(UpdateHabitActivity.ARG_HABIT, listOfHabits.get(habitIndex));
         }
         resultLauncher.launch(intent);
     }

--- a/app/src/main/java/com/example/ohthmhyh/fragments/HabitsTodayFragment.java
+++ b/app/src/main/java/com/example/ohthmhyh/fragments/HabitsTodayFragment.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
  */
 public class HabitsTodayFragment extends Fragment {
 
-    private HabitList habitList;
     private HabitTodayRecyclerViewAdapter adapter;
     private DatabaseAdapter databaseAdapter;
 
@@ -62,11 +61,7 @@ public class HabitsTodayFragment extends Fragment {
                     }
                 }
 
-                // Make the habitsToday into a HabitList for compatibility with the recyclerView adapter
-                HabitList habitList = new HabitList();
-                habitList.setHabitList(habitsToday);
-
-                adapter = new HabitTodayRecyclerViewAdapter(getContext(), habitList);
+                adapter = new HabitTodayRecyclerViewAdapter(getContext(), hList, habitsToday);
                 recyclerView.setAdapter(adapter);
                 recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
                 recyclerView.setHasFixedSize(true);


### PR DESCRIPTION
My mistake was that I allowed the HabitsTodayRecyclerViewAdapter to have its own HabitList instance that only contained the Habits for today.

When the user went to click the checkbox, the HabitList that only had the Habits for today would overwrite the master HabitList in the database. This would cause only the Habits for today to appear in the HabitFragment.

This change changes how the RecyclerViewAdapters for Habits take in arguments. The superclass (HabitRecyclerViewAdapter) only takes in a Context object and an ArrayList<Habit> object. This allows for flexibility in how subclasses are instantiated (i.e. they don't have to be instantiated with a HabitList which may require pulling from the database). Specific classes that have to manipulate Habits (add, delete, move, update, etc.) in the RecyclerView (like the HabitTodayRecyclerViewAdapter and HabitRecyclerViewGestureAdapter) will pass in a HabitList so that they can change Habits in the database.

In the future, when we hopefully have a DatabaseAdapter that can allow for manipulations of Habit objects in the database, we won't have to have a HabitList passed into the HabitTodayRecyclerViewAdapter and HabitRecyclerViewGestureAdapter.

Let me know if there are any other questions.