### PR TITLE
Prevent allowing going back after signing out

### DIFF
--- a/app/src/main/java/com/example/ohthmhyh/fragments/UserFragment.java
+++ b/app/src/main/java/com/example/ohthmhyh/fragments/UserFragment.java
@@ -204,6 +204,8 @@ public class UserFragment extends Fragment {
     private void goToLoginActivity() {
         // Go to the login activity from this fragment.
         Intent loginActivityIntent = new Intent(getActivity(), LoginActivity.class);
+        loginActivityIntent.setFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         startActivity(loginActivityIntent);
     }
 


### PR DESCRIPTION
Before these changes, if you signed out, you could still go back to the previously signed in user by pressing the back buttons.