### PR TITLE
Disable day toggle buttons on Habit edit

### DIFF
--- a/app/src/main/java/com/example/ohthmhyh/activities/UpdateHabitActivity.java
+++ b/app/src/main/java/com/example/ohthmhyh/activities/UpdateHabitActivity.java
@@ -192,5 +192,14 @@ public class UpdateHabitActivity extends AppCompatActivity implements DatePicker
 
         // Since the Habit already exists, its date cannot be edited.
         dateTextView.setEnabled(false);
+
+        // Since the Habit already exists, prevent days from being edited.
+        mondayToggleButton.setEnabled(false);
+        tuesdayToggleButton.setEnabled(false);
+        wednesdayToggleButton.setEnabled(false);
+        thursdayToggleButton.setEnabled(false);
+        fridayToggleButton.setEnabled(false);
+        saturdayToggleButton.setEnabled(false);
+        sundayToggleButton.setEnabled(false);
     }
 }


### PR DESCRIPTION
Not necessarily needed, but it would provide more congruency across the app and ensure that the Habit's score is consistent.

Will address #175.